### PR TITLE
chore(crowdin-sync.yml): enable file processing

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -46,6 +46,10 @@ jobs:
           pull_request_title: "New Crowdin Translations [${{ github.ref_name }}]"
           localization_branch_name: "l10n_crowdin_${{ github.ref_name }}"
           commit_message: "chore: new translations from Crowdin"
+          # Enable post-processing of files.
+          # This will remove Crowdin headers from PO files and avoid
+          # newlines at the end of files.
+          enable_file_processing: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}


### PR DESCRIPTION
Enable post-processing of translation files. This will remove Crowdin headers from PO files and avoid newlines at the end of files. This should help avoid unnecessary diffs when `lingui extract` is run, like here: https://github.com/warp-ds/icons/pull/51/commits/09f68a2e702a8d8ebfd9c0af7b45280a56b76b6b