### PR TITLE
fix(crowdin-sync.yml): remove if-statement from Checkout step

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -28,11 +28,9 @@ jobs:
       - name: Set vars
         # Define the rest of the env vars to make them reusable everywhere. GitHub actions expressions and variables are seriously confusing :|
         run: |
-          echo "do_run_verify_step=${{ (github.event_name == 'push' && ! fromJson(env.is_push_a_crowdin_pr_merge) ) || github.event_name == 'workflow_dispatch' }}" >> "$GITHUB_ENV"
           echo "do_run_crowdin_upload=${{ (github.event_name == 'push' && ! fromJson(env.is_push_a_crowdin_pr_merge) ) || github.event_name == 'workflow_dispatch' }}" >> "$GITHUB_ENV"
           echo "do_run_crowdin_download=${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}" >> "$GITHUB_ENV"
       - name: Checkout
-        if: ${{ fromJson(env.do_run_verify_step) }}
         uses: actions/checkout@v3
       - name: crowdin action
         uses: crowdin/github-action@v1


### PR DESCRIPTION
The repo that runs this workflow needs to be checked out for the config file to be found, so the if-statement shouldn't be there. This should fix jobs failing with `Configuration file doesn’t exist. Run the ‘crowdin init’ to generate configuration skeleton` ([example job](https://github.com/warp-ds/icons/actions/runs/7165932855/job/19508904884)). 