### PR TITLE
chore: remove '@warp-ds/' from team-reviewers

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -51,7 +51,7 @@ jobs:
           download_translations_args: "--skip-untranslated-files"
           pull_request_title: "New Crowdin Translations [${{ github.ref_name }}]"
           pull_request_reviewers: ${{ inputs.pull_request_reviewers || ''}}
-          pull_request_team_reviewers: ${{ inputs.pull_request_team_reviewers || '@warp-ds/warp-core-team'}}
+          pull_request_team_reviewers: ${{ inputs.pull_request_team_reviewers || 'warp-core-team'}}
           localization_branch_name: "l10n_crowdin_${{ github.ref_name }}"
           commit_message: "chore: new translations from Crowdin"
         env:


### PR DESCRIPTION
It turns out that [crowdin/github-action](https://github.com/crowdin/github-action/blob/33264f6f5146b48b49e0df3b7c82beeb727734d4/entrypoint.sh#L204-L208) sends the `pull_request_team_reviewers` value as part of body in a POST request to `/requested_reviewers` endpoint. That endpoint accepts an array of `slug` strings ([check GH API docs for more info](https://docs.github.com/en/rest/pulls/review-requests?apiVersion=2022-11-28#get-all-requested-reviewers-for-a-pull-request)), and we confirmed that "Warp Core Team"'s slug value is "warp-core-team".