### PR TITLE
fix: add GH_TOKEN to env variables

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -57,6 +57,7 @@ jobs:
           commit_message: "chore: new translations from Crowdin"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
           CROWDIN_API_TOKEN: ${{ secrets.CROWDIN_API_TOKEN }}
           CROWDIN_BASE_URL: ${{ vars.CROWDIN_BASE_URL }}


### PR DESCRIPTION
To use GitHub CLI in a GitHub Actions workflow, we need to set the GH_TOKEN environment variable.

This should fix an error when `backchannel_comments` job failed here: https://github.com/warp-ds/icons/actions/runs/7206956367/job/19632817992