### PR TITLE
fix: make env variables available in any job

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -27,6 +27,11 @@ env:
           && contains(github.event.head_commit.message, format('l10n_crowdin_{0}', github.ref_name))
         )
     }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
+  CROWDIN_API_TOKEN: ${{ secrets.CROWDIN_API_TOKEN }}
+  CROWDIN_BASE_URL: ${{ vars.CROWDIN_BASE_URL }}
 
 jobs:
   synchronize-with-crowdin:
@@ -55,12 +60,6 @@ jobs:
           pull_request_team_reviewers: ${{ inputs.pull_request_team_reviewers || 'warp-core-team'}}
           localization_branch_name: "l10n_crowdin_${{ github.ref_name }}"
           commit_message: "chore: new translations from Crowdin"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
-          CROWDIN_API_TOKEN: ${{ secrets.CROWDIN_API_TOKEN }}
-          CROWDIN_BASE_URL: ${{ vars.CROWDIN_BASE_URL }}
   backchannel-comments:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request_review_comment' && contains(github.event.pull_request.head.ref, 'l10n_crowdin') && (contains(github.event.comment.path, '.po') || contains(github.event.comment.path, '.properties')) }}


### PR DESCRIPTION
The `GH_TOKEN`, and possibly other env variables, should be available in the `backchannel_comments` job, so we shouldn't only defined them in the scope of the `synchronize-with-crowdin` job.