### PR TITLE
chore: remove default pull_request_team_reviewers

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -57,7 +57,7 @@ jobs:
           download_translations_args: "--skip-untranslated-files"
           pull_request_title: "New Crowdin Translations [${{ github.ref_name }}]"
           pull_request_reviewers: ${{ inputs.pull_request_reviewers || ''}}
-          pull_request_team_reviewers: ${{ inputs.pull_request_team_reviewers || 'warp-core-team'}}
+          pull_request_team_reviewers: ${{ inputs.pull_request_team_reviewers || '' }}
           localization_branch_name: "l10n_crowdin_${{ github.ref_name }}"
           commit_message: "chore: new translations from Crowdin"
   backchannel-comments:


### PR DESCRIPTION
When setting `warp-core-team` as `pull_request_team_reviewers` an error was thrown from Github API:
```
{
  "message": "Validation Failed",
  "errors": [
    "Could not resolve to a node with the global id of 'T_kwDOB0oBXs4AcLgd'."
  ],
  "documentation_url": "https://docs.github.com/rest/pulls/review-requests#request-reviewers-for-a-pull-request"
}
```

The reason seems to be that the default GITHUB_TOKEN permissions are not sufficient. We found this issue comment that summarizes what might need to be done for the workflow to assign team reviewers when a Crowdin PR is opened
[Use of team-reviewers results in: "Could not resolve to a node with the global id of..." error · Issue #155 · peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/issues/155#issuecomment-611904487)

Once the above is fixed we can consider restoring `warp-core-team` as the default team reviewer in this reusable workflow.